### PR TITLE
remove empty task ids

### DIFF
--- a/_common/de.abg.jreichert.activeanno.parent/oomph.setup
+++ b/_common/de.abg.jreichert.activeanno.parent/oomph.setup
@@ -1691,11 +1691,9 @@
   </setupTask>
   <setupTask
       xsi:type="setup:CompoundTask"
-      id=""
       name="Tasks">
     <setupTask
         xsi:type="setup:VariableTask"
-        id=""
         type="PASSWORD"
         name="github.user.password"
         label="GitHub password for issues"/>


### PR DESCRIPTION
Empty task ids lead can easily lead to validation errors, if another task also has an empty id by accident (since the IDs must be unique). I happened to copy your github task and suddenly had an error in an unrelated setup task.